### PR TITLE
Implement Bitwise core module

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -16,7 +16,8 @@
         "Elchemy.XChar",
         "Elchemy.XResult",
         "Elchemy.XTuple",
-        "Elchemy.XDebug"
+        "Elchemy.XDebug",
+        "Elchemy.XBitwise"
     ],
     "dependencies": {
         "elm-lang/core": "5.1.1 <= v < 6.0.0"

--- a/elm/Elchemy/XBitwise.elm
+++ b/elm/Elchemy/XBitwise.elm
@@ -48,6 +48,8 @@ and : Int -> Int -> Int
 and arg1 arg2 =
     to32Bits (and_ arg1 arg2)
 
+{- We don't verify since it's a macro -}
+{- flag noverify:+and_ -}
 
 and_ : Int -> Int -> Int
 and_ =
@@ -69,6 +71,9 @@ or arg1 arg2 =
     to32Bits (or_ arg1 arg2)
 
 
+{- We don't verify since it's a macro -}
+{- flag noverify:+or_ -}
+
 or_ : Int -> Int -> Int
 or_ =
     ffi "Bitwise" "bor"
@@ -89,6 +94,9 @@ xor arg1 arg2 =
     to32Bits (xor_ arg1 arg2)
 
 
+{- We don't verify since it's a macro -}
+{- flag noverify:+xor_ -}
+
 xor_ : Int -> Int -> Int
 xor_ =
     ffi "Bitwise" "bxor"
@@ -107,6 +115,9 @@ complement : Int -> Int
 complement arg =
     to32Bits (complement_ arg)
 
+
+{- We don't verify since it's a macro -}
+{- flag noverify:+complement_ -}
 
 complement_ : Int -> Int
 complement_ =
@@ -128,6 +139,9 @@ shiftLeftBy : Int -> Int -> Int
 shiftLeftBy shift int =
     to32Bits (shiftLeftBy_ int (mod_ shift integerBitSize))
 
+
+{- We don't verify since it's a macro -}
+{- flag noverify:+shiftLeftBy_ -}
 
 shiftLeftBy_ : Int -> Int -> Int
 shiftLeftBy_ =
@@ -161,6 +175,9 @@ shiftRightBy shift int =
     to32Bits (shiftRightBy_ int (mod_ shift integerBitSize))
 
 
+{- We don't verify since it's a macro -}
+{- flag noverify:+shiftRightBy_ -}
+
 shiftRightBy_ : Int -> Int -> Int
 shiftRightBy_ =
     ffi "Bitwise" "bsr"
@@ -192,6 +209,8 @@ zfMask : Int -> Int
 zfMask bits =
     (shiftLeftBy_ 1 (integerBitSize - bits)) - 1
 
+
+{- flag noverify:+to32Bits -}
 
 to32Bits : Int -> Int
 to32Bits int =

--- a/elm/Elchemy/XBitwise.elm
+++ b/elm/Elchemy/XBitwise.elm
@@ -1,0 +1,137 @@
+module Elchemy.XBitwise exposing
+  ( and, or, xor, complement
+  , shiftLeftBy, shiftRightBy, shiftRightZfBy
+  )
+
+{-| Library for [bitwise operations](http://en.wikipedia.org/wiki/Bitwise_operation).
+# Basic Operations
+@docs and, or, xor, complement
+# Bit Shifts
+@docs shiftLeftBy, shiftRightBy, shiftRightZfBy
+-}
+
+{- ex
+  use Bitwise
+-}
+
+import Elchemy exposing (..)
+
+integerBitSize = 32
+
+{-| Bitwise AND
+
+    and 0 0 == 0
+    and 1 1 == 1
+    and 4 1 == 0
+    and 102939 1 == 1
+
+-- truncates to 32 bits
+    and 92147483647 -1 == 1953170431
+
+-}
+and : Int -> Int -> Int
+and arg1 arg2 =
+    nativeAnd (to32Bits arg1) (to32Bits arg2)
+
+nativeAnd : Int -> Int -> Int
+nativeAnd =
+  ffi "Bitwise" "band"
+
+
+{-| Bitwise OR
+
+    or 0 0 == 0
+    or 1 1 == 1
+    or 4 1 == 5
+    or 102939 1 == 102939
+
+-}
+or : Int -> Int -> Int
+or =
+  ffi "Bitwise" "bor"
+
+
+{-| Bitwise XOR
+
+    Bitwise.xor 0 0 == 0
+    Bitwise.xor 1 1 == 0
+    Bitwise.xor 4 1 == 5
+    Bitwise.xor 102939 1 == 102938
+
+-}
+xor : Int -> Int -> Int
+xor =
+  ffi "Bitwise" "bxor"
+
+
+{-| Flip each bit individually, often called bitwise NOT
+
+    complement 0 == -1
+    complement 1 == -2
+    complement 102939 == -102940
+
+-}
+complement : Int -> Int
+complement =
+  ffi "Bitwise" "bnot"
+
+
+{-| Shift bits to the left by a given offset, filling new bits with zeros.
+This can be used to multiply numbers by powers of two.
+    shiftLeftBy 1 5 == 10
+    shiftLeftBy 5 1 == 32
+-}
+shiftLeftBy : Int -> Int -> Int
+shiftLeftBy shift int =
+    swappedShiftLeftBy int shift
+
+
+{- Swaps the argument order for ffi
+-}
+swappedShiftLeftBy : Int -> Int -> Int
+swappedShiftLeftBy =
+    ffi "Bitwise" "bsl"
+
+
+{-| Shift bits to the right by a given offset, filling new bits with
+whatever is the topmost bit. This can be used to divide numbers by powers of two.
+    shiftRightBy 1  32 == 16
+    shiftRightBy 2  32 == 8
+    shiftRightBy 1 -32 == -16
+This is called an [arithmetic right shift][ars], often written (>>), and
+sometimes called a sign-propagating right shift because it fills empty spots
+with copies of the highest bit.
+[ars]: http://en.wikipedia.org/wiki/Bitwise_operation#Arithmetic_shift
+-}
+shiftRightBy : Int -> Int -> Int
+shiftRightBy shift int =
+  nativeShiftRightBy int shift
+
+
+{- Swaps the argument order for ffi
+-}
+nativeShiftRightBy : Int -> Int -> Int
+nativeShiftRightBy =
+  ffi "Bitwise" "bsr"
+
+{-| Shift bits to the right by a given offset, filling new bits with zeros.
+    shiftRightZfBy 1  32 == 16
+    shiftRightZfBy 2  32 == 8
+    shiftRightZfBy 1 -32 == 2147483632
+This is called an [logical right shift][lrs], often written (>>>), and
+sometimes called a zero-fill right shift because it fills empty spots with
+zeros.
+[lrs]: http://en.wikipedia.org/wiki/Bitwise_operation#Logical_shift
+-}
+shiftRightZfBy : Int -> Int -> Int
+shiftRightZfBy shift int =
+  shiftRightBy shift int
+  |> and (mask shift)
+
+to32Bits : Int -> Int
+to32Bits int =
+    int |> and (mask 0)
+
+mask : Int -> Int
+mask bits =
+    (shiftLeftBy (integerBitSize - bits) 1) - 1

--- a/elm/Elchemy/XBitwise.elm
+++ b/elm/Elchemy/XBitwise.elm
@@ -1,22 +1,38 @@
-module Elchemy.XBitwise exposing
-  ( and, or, xor, complement
-  , shiftLeftBy, shiftRightBy, shiftRightZfBy
-  )
+module Elchemy.XBitwise
+    exposing
+        ( and
+        , or
+        , xor
+        , complement
+        , shiftLeftBy
+        , shiftRightBy
+        , shiftRightZfBy
+        )
 
 {-| Library for [bitwise operations](http://en.wikipedia.org/wiki/Bitwise_operation).
+
+
 # Basic Operations
+
 @docs and, or, xor, complement
+
+
 # Bit Shifts
+
 @docs shiftLeftBy, shiftRightBy, shiftRightZfBy
+
 -}
 
 {- ex
-  use Bitwise
+   use Bitwise
 -}
 
 import Elchemy exposing (..)
 
-integerBitSize = 32
+
+integerBitSize =
+    32
+
 
 {-| Bitwise AND
 
@@ -24,7 +40,6 @@ integerBitSize = 32
     and 1 1 == 1
     and 4 1 == 0
     and 102939 1 == 1
-
     -- truncates to 32 bits
     and 1099511627775 -1 == -1
 
@@ -36,7 +51,7 @@ and arg1 arg2 =
 
 and_ : Int -> Int -> Int
 and_ =
-  ffi "Bitwise" "band"
+    ffi "Bitwise" "band"
 
 
 {-| Bitwise OR
@@ -45,7 +60,6 @@ and_ =
     or 1 1 == 1
     or 4 1 == 5
     or 102939 1 == 102939
-
     -- truncates to 32 bits
     or 1099511627775 0 == -1
 
@@ -54,9 +68,10 @@ or : Int -> Int -> Int
 or arg1 arg2 =
     to32Bits (or_ arg1 arg2)
 
+
 or_ : Int -> Int -> Int
 or_ =
-  ffi "Bitwise" "bor"
+    ffi "Bitwise" "bor"
 
 
 {-| Bitwise XOR
@@ -65,7 +80,6 @@ or_ =
     Bitwise.xor 1 1 == 0
     Bitwise.xor 4 1 == 5
     Bitwise.xor 102939 1 == 102938
-
     -- truncates to 32 bits
     Bitwise.xor 1099511627775 1 == -2
 
@@ -74,16 +88,17 @@ xor : Int -> Int -> Int
 xor arg1 arg2 =
     to32Bits (xor_ arg1 arg2)
 
+
 xor_ : Int -> Int -> Int
 xor_ =
-  ffi "Bitwise" "bxor"
+    ffi "Bitwise" "bxor"
+
 
 {-| Flip each bit individually, often called bitwise NOT
 
     complement 0 == -1
     complement 1 == -2
     complement 102939 == -102940
-
     -- truncates to 32 bits
     complement 1099511627775 == 0
 
@@ -95,17 +110,19 @@ complement arg =
 
 complement_ : Int -> Int
 complement_ =
-  ffi "Bitwise" "bnot"
+    ffi "Bitwise" "bnot"
 
 
 {-| Shift bits to the left by a given offset, filling new bits with zeros.
 This can be used to multiply numbers by powers of two.
+
     shiftLeftBy 1 5 == 10
     shiftLeftBy 5 1 == 32
     -- shift is modulo 32 bits
     shiftLeftBy 32 1 == 1
     -- truncates to 32 bits
     shiftLeftBy 16 65535 == -65536
+
 -}
 shiftLeftBy : Int -> Int -> Int
 shiftLeftBy shift int =
@@ -115,6 +132,7 @@ shiftLeftBy shift int =
 shiftLeftBy_ : Int -> Int -> Int
 shiftLeftBy_ =
     ffi "Bitwise" "bsl"
+
 
 mod_ : Int -> Int -> Int
 mod_ =
@@ -135,16 +153,17 @@ whatever is the topmost bit. This can be used to divide numbers by powers of two
 This is called an [arithmetic right shift][ars], often written (>>), and
 sometimes called a sign-propagating right shift because it fills empty spots
 with copies of the highest bit.
-[ars]: http://en.wikipedia.org/wiki/Bitwise_operation#Arithmetic_shift
+[ars]: <http://en.wikipedia.org/wiki/Bitwise_operation#Arithmetic_shift>
+
 -}
 shiftRightBy : Int -> Int -> Int
 shiftRightBy shift int =
-  to32Bits (shiftRightBy_ int (mod_ shift integerBitSize))
+    to32Bits (shiftRightBy_ int (mod_ shift integerBitSize))
 
 
 shiftRightBy_ : Int -> Int -> Int
 shiftRightBy_ =
-  ffi "Bitwise" "bsr"
+    ffi "Bitwise" "bsr"
 
 
 {-| Shift bits to the right by a given offset, filling new bits with zeros.
@@ -156,31 +175,35 @@ shiftRightBy_ =
     shiftRightZfBy 32 1 == 1
     -- truncates to 32 bits
     shiftRightZfBy 1 1099511627775 == 2147483647
-    shiftRightZfBy 2 1099511627775 == 1073741823
 
 This is called an [logical right shift][lrs], often written (>>>), and
 sometimes called a zero-fill right shift because it fills empty spots with
 zeros.
-[lrs]: http://en.wikipedia.org/wiki/Bitwise_operation#Logical_shift
+[lrs]: <http://en.wikipedia.org/wiki/Bitwise_operation#Logical_shift>
+
 -}
 shiftRightZfBy : Int -> Int -> Int
 shiftRightZfBy shift int =
-  shiftRightBy shift int
-  |> and (zfMask (mod_ shift integerBitSize))
+    shiftRightBy shift int
+        |> and (zfMask (mod_ shift integerBitSize))
+
 
 zfMask : Int -> Int
 zfMask bits =
     (shiftLeftBy_ 1 (integerBitSize - bits)) - 1
 
+
 to32Bits : Int -> Int
 to32Bits int =
     ffi "Elchemy.XBitwise" "to_32_bits_"
 
+
+
 {- ex
 
-def to_32_bits_(int) do
-  << truncated :: integer-signed-32 >> = << int :: integer-signed-32 >>
-  truncated
-end
+   def to_32_bits_(int) do
+     << truncated :: integer-signed-32 >> = << int :: integer-signed-32 >>
+     truncated
+   end
 
 -}

--- a/lib/elchemy.ex
+++ b/lib/elchemy.ex
@@ -37,7 +37,8 @@ defmodule Elchemy do
         XTuple,
         XResult,
         XDict,
-        XSet
+        XSet,
+        XBitwise
       }
       import_std()
     end
@@ -53,7 +54,8 @@ defmodule Elchemy do
     Elchemy.XTuple,
     Elchemy.XResult,
     Elchemy.XDict,
-    Elchemy.XSet
+    Elchemy.XSet,
+    Elchemy.XBitwise
     ]
   defmacro import_std() do
     if Enum.member?(@std, __CALLER__.module) do

--- a/test/elchemy_test.exs
+++ b/test/elchemy_test.exs
@@ -25,10 +25,10 @@ defmodule ElchemyTest do
     Elchemy.XResult,
     Elchemy.XTuple,
     Elchemy.XDict,
+    Elchemy.XBitwise,
     Elchemy.XSet
   ])
   # No typetest for Debug because it loops forever on type resolution
   doctest Elchemy.XDebug
-  doctest Elchemy.XBitwise
 
 end

--- a/test/elchemy_test.exs
+++ b/test/elchemy_test.exs
@@ -29,5 +29,6 @@ defmodule ElchemyTest do
   ])
   # No typetest for Debug because it loops forever on type resolution
   doctest Elchemy.XDebug
+  doctest Elchemy.XBitwise
 
 end


### PR DESCRIPTION
Bitwise module for https://github.com/wende/elchemy/issues/189
A few items that probably need to be addressed still:
This requires a native elixir function to use elixirs bit syntax to convert ints to 32 bits, which is called via ffi from within the same module - unsure if there is a better way to implement a helper function like this.

When running tests or using in a project, compiling gives a warning:
```
warning: unused import Elchemy.XBitwise
```
because an `alias` expression is generated, but it is then also used by its fully qualified name. Not sure what the correct solution here is.

Compiling also says
```
warning: unused import Elchemy.XBasics
```
since this is imported by default, not sure how to silence this warning.